### PR TITLE
docs(string-service): Add javadoc

### DIFF
--- a/src/main/java/io/muehlbachler/bswe/StringService.java
+++ b/src/main/java/io/muehlbachler/bswe/StringService.java
@@ -2,10 +2,23 @@ package io.muehlbachler.bswe;
 
 import org.springframework.stereotype.Service;
 
-// FIXME: add javadoc
+/**
+ * Service class responsible for string operations.
+ * Provides functionality to convert strings to uppercase.
+ */
 @Service
 public class StringService {
-    // FIXME: add javadoc
+    /**
+     * Converts the provided string to uppercase.
+     *
+     * Edge cases:
+     * - If the input string is null, it returns null
+     * - Input should be in string format
+     * - If the input string is empty, it returns the empty string
+     *
+     * @param string the input string to be converted
+     * @return the input string converted to uppercase, or null if the input is null
+     */
     public String toUpperCase(final String string) {
         // FIXME: implement
         return string;


### PR DESCRIPTION
This PR does the following:

- Add Javadoc for **StringService** class
- Add Javadoc for **toUpperCase** method
- Remove 'example.txt' file